### PR TITLE
Fix a minor bug not detected by unit tests

### DIFF
--- a/ffsend.py
+++ b/ffsend.py
@@ -310,7 +310,7 @@ def main(argv):
         if params:
             if not args.token:
                 parser.error("setting parameters requires -t/--token")
-            set_params(fid, args.token, **params)
+            set_params(service, fid, args.token, **params)
             print("File parameters %s set" % str(params))
             return True
         return False


### PR DESCRIPTION
I forgot to change the way to call set_params in do_set_params after
changing the difinition of set_params. Now it get fixed.

All existing unit tests is passed.